### PR TITLE
fix(response): remove null values from JSON-RPC response

### DIFF
--- a/src/Controller/EntrypointController.php
+++ b/src/Controller/EntrypointController.php
@@ -7,8 +7,8 @@ namespace Ecourty\McpServerBundle\Controller;
 use Ecourty\McpServerBundle\Exception\MethodHandlerNotFoundException;
 use Ecourty\McpServerBundle\Exception\RequestHandlingException;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
-use Ecourty\McpServerBundle\HttpFoundation\JsonRpcResponse;
 use Ecourty\McpServerBundle\Service\MethodHandlerRegistry;
+use Ecourty\McpServerBundle\Service\ResponseFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +26,7 @@ class EntrypointController extends AbstractController
 {
     public function __construct(
         private readonly MethodHandlerRegistry $methodHandlerRegistry,
+        private readonly ResponseFactory $responseFactory,
     ) {
     }
 
@@ -48,10 +49,9 @@ class EntrypointController extends AbstractController
             throw new RequestHandlingException($exception);
         }
 
-        return $this->json(new JsonRpcResponse(
+        return $this->responseFactory->success(
             id: $jsonRpcRequest->id,
             result: $response,
-            error: null,
-        ));
+        );
     }
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -7,16 +7,12 @@ namespace Ecourty\McpServerBundle\EventListener;
 use Ecourty\McpServerBundle\Enum\McpErrorCode;
 use Ecourty\McpServerBundle\Exception\MethodHandlerNotFoundException;
 use Ecourty\McpServerBundle\Exception\RequestHandlingException;
-use Ecourty\McpServerBundle\HttpFoundation\JsonRpcError;
-use Ecourty\McpServerBundle\HttpFoundation\JsonRpcResponse;
+use Ecourty\McpServerBundle\Service\ResponseFactory;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Validator\ConstraintViolationInterface;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * Handles exceptions thrown during the request handling process.
@@ -28,6 +24,7 @@ class ExceptionListener
 {
     public function __construct(
         private readonly RequestStack $requestStack,
+        private readonly ResponseFactory $responseFactory,
     ) {
     }
 
@@ -35,43 +32,25 @@ class ExceptionListener
     {
         $request = $this->requestStack->getCurrentRequest();
         $jsonRpcRequestId = $request?->attributes->get('json_rpc_request_id');
-
         $exception = $event->getThrowable();
 
         $event->allowCustomResponseCode();
 
-        if ($exception instanceof UnprocessableEntityHttpException) {
-            $event->setResponse(new JsonResponse($this->buildErrorResponse(
-                jsonRpcRequestId: $jsonRpcRequestId,
-                errorCode: McpErrorCode::PARSE_ERROR,
-            )));
-            return;
-        }
+        $response = match (true) {
+            $exception instanceof UnprocessableEntityHttpException =>
+                $this->responseFactory->error($jsonRpcRequestId, McpErrorCode::PARSE_ERROR),
 
-        if ($exception instanceof MethodHandlerNotFoundException) {
-            $event->setResponse(new JsonResponse($this->buildErrorResponse(
-                jsonRpcRequestId: $jsonRpcRequestId,
-                errorCode: McpErrorCode::TOOL_NOT_FOUND,
-            )));
-            return;
-        }
+            $exception instanceof MethodHandlerNotFoundException =>
+                $this->responseFactory->error($jsonRpcRequestId, McpErrorCode::TOOL_NOT_FOUND),
 
-        if ($exception instanceof RequestHandlingException) {
-            $event->setResponse(new JsonResponse($this->buildErrorResponse(
-                jsonRpcRequestId: $jsonRpcRequestId,
-                errorCode: McpErrorCode::INTERNAL_ERROR,
-            )));
-        }
-    }
+            $exception instanceof RequestHandlingException =>
+                $this->responseFactory->error($jsonRpcRequestId, McpErrorCode::INTERNAL_ERROR),
 
-    private function buildErrorResponse(
-        int|string|null $jsonRpcRequestId,
-        McpErrorCode $errorCode,
-    ): JsonRpcResponse {
-        return new JsonRpcResponse(
-            id: $jsonRpcRequestId,
-            result: null,
-            error: new JsonRpcError(code: $errorCode, message: $errorCode->getMessage()),
-        );
+            default => null,
+        };
+
+        if ($response !== null) {
+            $event->setResponse($response);
+        }
     }
 }

--- a/src/Service/ResponseFactory.php
+++ b/src/Service/ResponseFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Service;
+
+use Ecourty\McpServerBundle\Enum\McpErrorCode;
+use Ecourty\McpServerBundle\HttpFoundation\JsonRpcError;
+use Ecourty\McpServerBundle\HttpFoundation\JsonRpcResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Factory for creating JSON-RPC responses.
+ */
+class ResponseFactory
+{
+    public function __construct(
+        private readonly SerializerInterface $serializer,
+    ) {
+    }
+
+    public function success(int|string|null $id, mixed $result): JsonResponse
+    {
+        return $this->createResponse(new JsonRpcResponse(
+            id: $id,
+            result: $result,
+            error: null,
+        ));
+    }
+
+    public function error(int|string|null $id, McpErrorCode $errorCode): JsonResponse
+    {
+        return $this->createResponse(new JsonRpcResponse(
+            id: $id,
+            result: null,
+            error: new JsonRpcError(
+                code: $errorCode,
+                message: $errorCode->getMessage(),
+            ),
+        ));
+    }
+
+    private function createResponse(JsonRpcResponse $response): JsonResponse
+    {
+        $json = $this->serializer->serialize($response, 'json', [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]);
+
+        return JsonResponse::fromJsonString($json, JsonResponse::HTTP_OK);
+    }
+}

--- a/tests/Controller/EntrypointControllerTest.php
+++ b/tests/Controller/EntrypointControllerTest.php
@@ -29,12 +29,9 @@ class EntrypointControllerTest extends WebTestCase
 
         $this->assertSame([
             'jsonrpc' => '2.0',
-            'id' => null,
-            'result' => null,
             'error' => [
                 'code' => McpErrorCode::PARSE_ERROR->value,
                 'message' => McpErrorCode::PARSE_ERROR->getMessage(),
-                'data' => null,
             ],
         ], $responseContent);
     }
@@ -45,6 +42,8 @@ class EntrypointControllerTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => 'initialize',
                 'params' => [],
             ],
@@ -54,6 +53,7 @@ class EntrypointControllerTest extends WebTestCase
         $this->assertNotFalse($responseContent);
 
         $this->assertArrayHasKey('result', $responseContent);
+        $this->assertArrayNotHasKey('error', $responseContent);
 
         $resultContent = $responseContent['result'];
 
@@ -82,6 +82,7 @@ class EntrypointControllerTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
                 'id' => $requestId,
                 'method' => 'tools/list',
                 'params' => [],
@@ -206,6 +207,8 @@ class EntrypointControllerTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => 'tools/non_existing_tool',
                 'params' => [],
             ],
@@ -216,12 +219,10 @@ class EntrypointControllerTest extends WebTestCase
 
         $this->assertSame([
             'jsonrpc' => '2.0',
-            'id' => null,
-            'result' => null,
+            'id' => 1,
             'error' => [
                 'code' => McpErrorCode::TOOL_NOT_FOUND->value,
                 'message' => McpErrorCode::TOOL_NOT_FOUND->getMessage(),
-                'data' => null,
             ],
         ], $responseContent);
     }
@@ -236,6 +237,8 @@ class EntrypointControllerTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => 'tools/call',
                 'params' => [
                     'name' => 'sum_numbers',
@@ -249,12 +252,10 @@ class EntrypointControllerTest extends WebTestCase
 
         $this->assertSame([
             'jsonrpc' => '2.0',
-            'id' => null,
-            'result' => null,
+            'id' => 1,
             'error' => [
                 'code' => McpErrorCode::INTERNAL_ERROR->value,
                 'message' => McpErrorCode::INTERNAL_ERROR->getMessage(),
-                'data' => null,
             ],
         ], $responseContent);
     }
@@ -270,6 +271,8 @@ class EntrypointControllerTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => $method,
                 'params' => $params,
             ],
@@ -294,7 +297,7 @@ class EntrypointControllerTest extends WebTestCase
             ],
             'expectedResponse' => [
                 'jsonrpc' => '2.0',
-                'id' => null,
+                'id' => 1,
                 'result' => [
                     'content' => [
                         [
@@ -303,7 +306,6 @@ class EntrypointControllerTest extends WebTestCase
                         ],
                     ],
                 ],
-                'error' => null,
             ],
         ];
 
@@ -318,7 +320,7 @@ class EntrypointControllerTest extends WebTestCase
             ],
             'expectedResponse' => [
                 'jsonrpc' => '2.0',
-                'id' => null,
+                'id' => 1,
                 'result' => [
                     'content' => [
                         [
@@ -327,7 +329,6 @@ class EntrypointControllerTest extends WebTestCase
                         ],
                     ],
                 ],
-                'error' => null,
             ],
         ];
     }

--- a/tests/Validation/InputSchemaValidationTest.php
+++ b/tests/Validation/InputSchemaValidationTest.php
@@ -18,6 +18,8 @@ class InputSchemaValidationTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => 'tools/call',
                 'params' => [
                     'name' => 'create_user',
@@ -32,7 +34,7 @@ class InputSchemaValidationTest extends WebTestCase
         $parsedResponse = json_decode((string) $response->getContent(), true);
         $this->assertSame([
             'jsonrpc' => '2.0',
-            'id' => null,
+            'id' => 1,
             'result' => [
                 'isError' => true,
                 'content' => [
@@ -42,7 +44,6 @@ class InputSchemaValidationTest extends WebTestCase
                     ],
                 ],
             ],
-            'error' => null,
         ], $parsedResponse);
     }
 
@@ -52,6 +53,8 @@ class InputSchemaValidationTest extends WebTestCase
             method: Request::METHOD_POST,
             url: '/mcp',
             body: [
+                'jsonrpc' => '2.0',
+                'id' => 1,
                 'method' => 'tools/call',
                 'params' => [
                     'name' => 'create_user',
@@ -66,7 +69,7 @@ class InputSchemaValidationTest extends WebTestCase
         $parsedResponse = json_decode((string) $response->getContent(), true);
         $this->assertSame([
             'jsonrpc' => '2.0',
-            'id' => null,
+            'id' => 1,
             'result' => [
                 'isError' => true,
                 'content' => [
@@ -76,7 +79,6 @@ class InputSchemaValidationTest extends WebTestCase
                     ],
                 ],
             ],
-            'error' => null,
         ], $parsedResponse);
     }
 }


### PR DESCRIPTION
This pull request introduces a `ResponseFactory` class to standardize the creation of JSON-RPC responses across the codebase. The changes replace direct instantiation of `JsonRpcResponse` objects with methods from the new factory class, improving maintainability and consistency. Additionally, test cases have been updated to reflect these changes and ensure compatibility.

### Refactoring for Response Handling:
* [`src/Controller/EntrypointController.php`](diffhunk://#diff-a5c2ef7b59b7d68c04f78acfa552448deff8b35a6b0742440ab816b791a71940L10-R11): Replaced direct use of `JsonRpcResponse` with `ResponseFactory` for success responses, and added `ResponseFactory` as a dependency in the constructor. [[1]](diffhunk://#diff-a5c2ef7b59b7d68c04f78acfa552448deff8b35a6b0742440ab816b791a71940L10-R11) [[2]](diffhunk://#diff-a5c2ef7b59b7d68c04f78acfa552448deff8b35a6b0742440ab816b791a71940R29) [[3]](diffhunk://#diff-a5c2ef7b59b7d68c04f78acfa552448deff8b35a6b0742440ab816b791a71940L51-R55)
* [`src/EventListener/ExceptionListener.php`](diffhunk://#diff-ca37dcb730a2c45e59e8af23f9b091841f61998ca37846c41ab511dc88dbf05fL10-L19): Replaced multiple error response handling blocks with a unified approach using `ResponseFactory` methods, and added `ResponseFactory` as a dependency in the constructor. [[1]](diffhunk://#diff-ca37dcb730a2c45e59e8af23f9b091841f61998ca37846c41ab511dc88dbf05fL10-L19) [[2]](diffhunk://#diff-ca37dcb730a2c45e59e8af23f9b091841f61998ca37846c41ab511dc88dbf05fR27-R54)

### Addition of `ResponseFactory`:
* [`src/Service/ResponseFactory.php`](diffhunk://#diff-897cd2d45acfbe7429bce0233ac5cdb3203633962f1c5754bc353ed1e752866dR1-R53): Introduced a new class to encapsulate the logic for creating JSON-RPC success and error responses, ensuring consistency and reusability across the application.

### Updates to Test Cases:
* [`tests/Controller/EntrypointControllerTest.php`](diffhunk://#diff-868c3e403c4a5558b3dfe6e21d8e8aacd494b1e5500deff1a680b03b63d93fa2L32-L37): Updated test cases to include `jsonrpc` version and request IDs in the request body and expected responses, aligning with the new response format. [[1]](diffhunk://#diff-868c3e403c4a5558b3dfe6e21d8e8aacd494b1e5500deff1a680b03b63d93fa2L32-L37) [[2]](diffhunk://#diff-868c3e403c4a5558b3dfe6e21d8e8aacd494b1e5500deff1a680b03b63d93fa2L219-L224) [[3]](diffhunk://#diff-868c3e403c4a5558b3dfe6e21d8e8aacd494b1e5500deff1a680b03b63d93fa2L252-L257)
* [`tests/Validation/InputSchemaValidationTest.php`](diffhunk://#diff-a24f58b386a91f37d3f7f51262cecc38e7006f00e51aa6a3afbe4f64ba9e8bfcR21-R22): Modified test cases to reflect the updated response structure, including `jsonrpc` version and request IDs. [[1]](diffhunk://#diff-a24f58b386a91f37d3f7f51262cecc38e7006f00e51aa6a3afbe4f64ba9e8bfcR21-R22) [[2]](diffhunk://#diff-a24f58b386a91f37d3f7f51262cecc38e7006f00e51aa6a3afbe4f64ba9e8bfcL69-R72)