### PR TITLE
chore(deps): allow symfony 6.4 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,21 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "^7.3",
+        "php": "^8.1",
+        "symfony/framework-bundle": "^6.4 || ^7.0",
         "symfony/serializer-pack": "^1.3",
-        "symfony/http-kernel": "^7.3",
-        "symfony/validator": "^7.3",
-        "zircote/swagger-php": "^5.1",
-        "symfony/console": "^7.3",
-        "symfony/runtime": "^7.3"
+        "symfony/http-kernel": "^6.4 || ^7.0",
+        "symfony/validator": "^6.4 || ^7.0",
+        "symfony/console": "^6.4 || ^7.0",
+        "symfony/runtime": "^6.4 || ^7.0",
+        "zircote/swagger-php": "^5.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpunit/phpunit": "^12.1",
-        "symfony/browser-kit": "^7.3",
-        "symfony/yaml": "^7.3"
+        "symfony/browser-kit": "^6.4 || ^7.0",
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request updates the `composer.json` file to adjust dependencies for compatibility with PHP 8.1 and Symfony versions 6.4 and 7.0. The changes ensure the project can support a broader range of versions while maintaining functionality.

Dependency updates:

* Updated the `php` requirement to `^8.1` to specify compatibility with PHP 8.1.
* Adjusted Symfony dependencies (`framework-bundle`, `http-kernel`, `validator`, `console`, `runtime`, `browser-kit`, and `yaml`) to support versions `^6.4 || ^7.0` for broader compatibility.
* Retained the `zircote/swagger-php` dependency at `^5.1` without changes.