### PR TITLE
feat(prompt): support unsafe arguments

### DIFF
--- a/src/Prompt/Argument.php
+++ b/src/Prompt/Argument.php
@@ -9,15 +9,20 @@ namespace Ecourty\McpServerBundle\Prompt;
  */
 class Argument
 {
+    /**
+     * @param bool $required Indicates if the argument is required (will throw an error if true and not provided).
+     * @param bool $allowUnsafe Indicates if the argument allows unsafe content (will not be sanitized if true).
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $description,
         public readonly bool $required = true,
+        public readonly bool $allowUnsafe = false,
     ) {
     }
 
     /**
-     * @return array{name: string, description: string, required: bool}
+     * @return array{name: string, description: string, required: bool, allowUnsafe: bool}
      */
     public function toArray(): array
     {
@@ -25,6 +30,7 @@ class Argument
             'name' => $this->name,
             'description' => $this->description,
             'required' => $this->required,
+            'allowUnsafe' => $this->allowUnsafe,
         ];
     }
 }

--- a/src/Service/PromptRegistry.php
+++ b/src/Service/PromptRegistry.php
@@ -53,7 +53,7 @@ class PromptRegistry
     /**
      * @internal
      *
-     * @param array<array{name: string, description: string, required: bool}> $argumentDefinitions
+     * @param array<array{name: string, description: string, required: bool, allowUnsafe: bool}> $argumentDefinitions
      */
     public function addPromptDefinition(
         string $name,
@@ -70,6 +70,7 @@ class PromptRegistry
                 name: $argumentDefinition['name'],
                 description: $argumentDefinition['description'],
                 required: $argumentDefinition['required'],
+                allowUnsafe: $argumentDefinition['allowUnsafe'],
             );
         }
 

--- a/tests/Service/PromptRegistryTest.php
+++ b/tests/Service/PromptRegistryTest.php
@@ -62,7 +62,7 @@ class PromptRegistryTest extends KernelTestCase
                 'name' => 'generate-git-commit-message',
                 'expectedDescription' => 'Generate a git commit message based on the provided changes.',
                 'expectedArguments' => [
-                    new Argument('changes', 'The changed made in the codebase', true),
+                    new Argument('changes', 'The changed made in the codebase', true, true),
                     new Argument('scope', 'The scope of the changes, e.g., feature, bugfix, etc.', true),
                 ],
             ],

--- a/tests/TestApp/src/Prompt/GenerateGitCommitMessage.php
+++ b/tests/TestApp/src/Prompt/GenerateGitCommitMessage.php
@@ -16,7 +16,7 @@ use Ecourty\McpServerBundle\Prompt\Argument;
     name: 'generate-git-commit-message',
     description: 'Generate a git commit message based on the provided changes.',
     arguments: [
-        new Argument(name: 'changes', description: 'The changed made in the codebase'),
+        new Argument(name: 'changes', description: 'The changed made in the codebase', allowUnsafe: true),
         new Argument(name: 'scope', description: 'The scope of the changes, e.g., feature, bugfix, etc.'),
     ],
 )]

--- a/tests/TestApp/src/Prompt/GreetingPrompt.php
+++ b/tests/TestApp/src/Prompt/GreetingPrompt.php
@@ -15,7 +15,7 @@ use Ecourty\McpServerBundle\Prompt\Argument;
 #[AsPrompt(
     name: 'greeting',
     arguments: [
-        new Argument('name', description: 'The name of the person to greet.', required: false),
+        new Argument('name', description: 'The name of the person to greet.', required: false, allowUnsafe: true),
     ],
 )]
 class GreetingPrompt


### PR DESCRIPTION
This PR adds support for unsafe prompt arguments.

Arguments that could be flagged as unsafe are piece of codes, or specifically-formatted text (with html tags for example)