### PR TITLE
chore(style): add @Symfony php-cs-fixer rule

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,6 +11,7 @@ return $config
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR12' => true,
+        '@Symfony' => true,
         'simplified_null_return' => false,
         'concat_space' => ['spacing' => 'one'],
         'phpdoc_summary' => false,

--- a/src/Attribute/AsMethodHandler.php
+++ b/src/Attribute/AsMethodHandler.php
@@ -11,7 +11,7 @@ namespace Ecourty\McpServerBundle\Attribute;
 class AsMethodHandler
 {
     /**
-     * @param string $methodName The JSON-RPC method name that the handler will respond to.
+     * @param string $methodName the JSON-RPC method name that the handler will respond to
      */
     public function __construct(
         public string $methodName,

--- a/src/Attribute/AsPrompt.php
+++ b/src/Attribute/AsPrompt.php
@@ -15,9 +15,9 @@ class AsPrompt
     private readonly array $arguments;
 
     /**
-     * @param string $name The name of the prompt.
-     * @param string|null $description A description of the prompt.
-     * @param array<Argument|mixed> $arguments An array of argument definitions for the prompt.
+     * @param string                $name        the name of the prompt
+     * @param string|null           $description a description of the prompt
+     * @param array<Argument|mixed> $arguments   an array of argument definitions for the prompt
      */
     public function __construct(
         public readonly string $name,

--- a/src/Attribute/AsTool.php
+++ b/src/Attribute/AsTool.php
@@ -16,9 +16,9 @@ class AsTool
     private readonly ToolAnnotations $toolAnnotations;
 
     /**
-     * @param string $name The name of the tool, which can be called by clients.
-     * @param string $description A human-readable description of the tool, useful for LLMs to understand its purpose.
-     * @param ToolAnnotations|null $annotations Optional annotations for the tool, providing additional metadata such as title, read-only status, and hints about the tool's behavior.
+     * @param string               $name        the name of the tool, which can be called by clients
+     * @param string               $description a human-readable description of the tool, useful for LLMs to understand its purpose
+     * @param ToolAnnotations|null $annotations optional annotations for the tool, providing additional metadata such as title, read-only status, and hints about the tool's behavior
      */
     public function __construct(
         public string $name,

--- a/src/Attribute/ToolAnnotations.php
+++ b/src/Attribute/ToolAnnotations.php
@@ -13,11 +13,11 @@ namespace Ecourty\McpServerBundle\Attribute;
 class ToolAnnotations
 {
     /**
-     * @param string $title A human-readable title for the tool, useful for UI display
-     * @param bool $readOnlyHint If true, indicates the tool does not modify its environment
-     * @param bool $destructiveHint If true, the tool may perform destructive updates (only meaningful when readOnlyHint is false)
-     * @param bool $idempotentHint If true, calling the tool repeatedly with the same arguments has no additional effect (only meaningful when readOnlyHint is false)
-     * @param bool $openWorldHint If true, the tool may interact with an “open world” of external entities
+     * @param string $title           A human-readable title for the tool, useful for UI display
+     * @param bool   $readOnlyHint    If true, indicates the tool does not modify its environment
+     * @param bool   $destructiveHint If true, the tool may perform destructive updates (only meaningful when readOnlyHint is false)
+     * @param bool   $idempotentHint  If true, calling the tool repeatedly with the same arguments has no additional effect (only meaningful when readOnlyHint is false)
+     * @param bool   $openWorldHint   If true, the tool may interact with an “open world” of external entities
      */
     public function __construct(
         public readonly string $title = '',

--- a/src/Exception/RequestHandlingException.php
+++ b/src/Exception/RequestHandlingException.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Ecourty\McpServerBundle\Exception;
 
-use Throwable;
-
 /**
  * Exception thrown when there is an error handling a JSON-RPC request.
  */
 class RequestHandlingException extends \Exception
 {
-    public function __construct(Throwable $previous)
+    public function __construct(\Throwable $previous)
     {
         parent::__construct($previous->getMessage(), $previous->getCode(), $previous);
     }

--- a/src/IO/ToolResult.php
+++ b/src/IO/ToolResult.php
@@ -8,7 +8,7 @@ use Ecourty\McpServerBundle\Contract\ToolResultInterface;
 
 class ToolResult
 {
-    /** @var ToolResultInterface[] $elements */
+    /** @var ToolResultInterface[] */
     private array $elements = [];
     private bool $isError = false;
 

--- a/src/Prompt/Argument.php
+++ b/src/Prompt/Argument.php
@@ -10,8 +10,8 @@ namespace Ecourty\McpServerBundle\Prompt;
 class Argument
 {
     /**
-     * @param bool $required Indicates if the argument is required (will throw an error if true and not provided).
-     * @param bool $allowUnsafe Indicates if the argument allows unsafe content (will not be sanitized if true).
+     * @param bool $required    indicates if the argument is required (will throw an error if true and not provided)
+     * @param bool $allowUnsafe indicates if the argument allows unsafe content (will not be sanitized if true)
      */
     public function __construct(
         public readonly string $name,

--- a/src/Service/SchemaExtractor.php
+++ b/src/Service/SchemaExtractor.php
@@ -8,8 +8,6 @@ use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use OpenApi\Generator;
-use ReflectionClass;
-use ReflectionProperty;
 
 /**
  * Extracts schema information from a class using OpenAPI attributes.
@@ -24,10 +22,10 @@ class SchemaExtractor
      */
     public function extract(string $class): array
     {
-        $reflection = new ReflectionClass($class);
+        $reflection = new \ReflectionClass($class);
         $properties = [];
 
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
             $attribute = $this->getPropertyAttribute($property);
 
             if ($attribute === null) {
@@ -94,7 +92,7 @@ class SchemaExtractor
         return $value === Generator::UNDEFINED ? $default : $value;
     }
 
-    private function getPropertyAttribute(ReflectionProperty $property): ?Property
+    private function getPropertyAttribute(\ReflectionProperty $property): ?Property
     {
         $propertyAttributes = $property->getAttributes(Property::class);
 
@@ -105,7 +103,7 @@ class SchemaExtractor
         return $propertyAttributes[0]->newInstance();
     }
 
-    private function getSchemaAttribute(ReflectionClass $class): ?Schema // @phpstan-ignore missingType.generics
+    private function getSchemaAttribute(\ReflectionClass $class): ?Schema // @phpstan-ignore missingType.generics
     {
         $schemaAttributes = $class->getAttributes(Schema::class);
 

--- a/tests/TestApp/src/Prompt/GenerateGitCommitMessage.php
+++ b/tests/TestApp/src/Prompt/GenerateGitCommitMessage.php
@@ -9,8 +9,8 @@ use Ecourty\McpServerBundle\Enum\PromptRole;
 use Ecourty\McpServerBundle\IO\Prompt\Content\TextContent;
 use Ecourty\McpServerBundle\IO\Prompt\PromptMessage;
 use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
-use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
 use Ecourty\McpServerBundle\Prompt\Argument;
+use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
 
 #[AsPrompt(
     name: 'generate-git-commit-message',

--- a/tests/TestApp/src/Prompt/GreetingPrompt.php
+++ b/tests/TestApp/src/Prompt/GreetingPrompt.php
@@ -9,8 +9,8 @@ use Ecourty\McpServerBundle\Enum\PromptRole;
 use Ecourty\McpServerBundle\IO\Prompt\Content\TextContent;
 use Ecourty\McpServerBundle\IO\Prompt\PromptMessage;
 use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
-use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
 use Ecourty\McpServerBundle\Prompt\Argument;
+use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
 
 #[AsPrompt(
     name: 'greeting',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ use Symfony\Component\ErrorHandler\ErrorHandler;
 
 require \dirname(__DIR__) . '/vendor/autoload.php';
 
-/**
+/*
  * @see https://github.com/symfony/symfony/issues/53812
  */
 set_exception_handler([new ErrorHandler(), 'handleException']);


### PR DESCRIPTION
The PR adds the `@Symfony` rule in the php-cs-fixer configuration and fixes the linked code style issues.