### PR TITLE
Improved Symfony 6.4 Support

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,8 +28,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('server')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->stringNode('name')->defaultValue(self::DEFAULT_NAME)->end()
-                        ->stringNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
+                        ->scalarNode('name')->defaultValue(self::DEFAULT_NAME)->end()
+                        ->scalarNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/Service/ResponseFactory.php
+++ b/src/Service/ResponseFactory.php
@@ -46,6 +46,7 @@ class ResponseFactory
     {
         $json = $this->serializer->serialize($response, 'json', [
             AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
         ]);
 
         return JsonResponse::fromJsonString($json, JsonResponse::HTTP_OK);


### PR DESCRIPTION
Swap stringNode to scalarNode due to method only being added in Symfony 7.2
Add AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS to ResponseFactory.php to ensure empty arrays return as json objects to satisfy cursor initialise