### PR TITLE
fix(config): update configuration to fix Symfony 6.4 format

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,8 +28,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('server')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->stringNode('name')->defaultValue(self::DEFAULT_NAME)->end()
-                        ->stringNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
+                        ->scalarNode('name')->defaultValue(self::DEFAULT_NAME)->end()
+                        ->scalarNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
                     ->end()
                 ->end()
             ->end();


### PR DESCRIPTION
This pull request includes a minor change to the `getConfigTreeBuilder` method in `src/DependencyInjection/Configuration.php`. The change updates the node type for `name` and `version` from `stringNode` to `scalarNode`.

* **Configuration update**:
  * Changed `stringNode` to `scalarNode` for the `name` and `version` fields in the `server` configuration array to allow broader scalar types. (`[src/DependencyInjection/Configuration.phpL31-R32](diffhunk://#diff-ebe00144d6cecb5ca8a2860883e01147f42bbed2b12a3a7f44915908a4829faaL31-R32)`)