### PR TITLE
feat: implement support for multiple servers

### DIFF
--- a/src/Attribute/AsPrompt.php
+++ b/src/Attribute/AsPrompt.php
@@ -18,11 +18,13 @@ class AsPrompt
      * @param string                $name        the name of the prompt
      * @param string|null           $description a description of the prompt
      * @param array<Argument|mixed> $arguments   an array of argument definitions for the prompt
+     * @param string|null           $server      optional server key to specify which server this prompt belongs to (if multiple servers are configured)
      */
     public function __construct(
         public readonly string $name,
         public readonly ?string $description = null,
         array $arguments = [],
+        public readonly ?string $server = null,
     ) {
         foreach ($arguments as $argument) {
             if ($argument instanceof Argument === false) {

--- a/src/Attribute/AsResource.php
+++ b/src/Attribute/AsResource.php
@@ -14,6 +14,7 @@ class AsResource
         public readonly ?string $description = null, // Optional description
         public readonly ?string $mimeType = null, // Optional MIME type of the resource
         public readonly ?string $size = null, // Optional size of the resource, in bytes
+        public readonly ?string $server = null, // Optional server key to specify which server this resource belongs to (if multiple servers are configured)
     ) {
     }
 

--- a/src/Attribute/AsTool.php
+++ b/src/Attribute/AsTool.php
@@ -19,11 +19,13 @@ class AsTool
      * @param string               $name        the name of the tool, which can be called by clients
      * @param string               $description a human-readable description of the tool, useful for LLMs to understand its purpose
      * @param ToolAnnotations|null $annotations optional annotations for the tool, providing additional metadata such as title, read-only status, and hints about the tool's behavior
+     * @param string|null          $server      optional server key to specify which server this tool belongs to (if multiple servers are configured)
      */
     public function __construct(
         public string $name,
         public string $description,
         ?ToolAnnotations $annotations = null,
+        public ?string $server = null,
     ) {
         $this->toolAnnotations = $annotations ?? new ToolAnnotations();
     }

--- a/src/Command/DebugMcpPromptsCommand.php
+++ b/src/Command/DebugMcpPromptsCommand.php
@@ -7,7 +7,6 @@ namespace Ecourty\McpServerBundle\Command;
 use Ecourty\McpServerBundle\Prompt\Argument;
 use Ecourty\McpServerBundle\Prompt\PromptDefinition;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
-use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -29,7 +28,6 @@ class DebugMcpPromptsCommand extends Command
 {
     public function __construct(
         private readonly PromptRegistry $promptRegistry,
-        private readonly ServerConfigurationRegistry $serverConfigurationRegistry,
     ) {
         parent::__construct();
     }
@@ -64,7 +62,7 @@ class DebugMcpPromptsCommand extends Command
         }
 
         $serverKey = $this->promptRegistry->getPromptServerKey($promptName);
-        $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+        $serverInfo = $serverKey ?? 'Global';
 
         $io->table(
             ['Name', 'Description', 'Server', 'Arguments'],
@@ -97,7 +95,7 @@ class DebugMcpPromptsCommand extends Command
             ['Name', 'Description', 'Server', 'Arguments'],
             array_map(function (PromptDefinition $prompt) {
                 $serverKey = $this->promptRegistry->getPromptServerKey($prompt->name);
-                $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+                $serverInfo = $serverKey ?? 'Global';
 
                 return [
                     $prompt->name,
@@ -109,15 +107,5 @@ class DebugMcpPromptsCommand extends Command
         );
 
         return self::SUCCESS;
-    }
-
-    private function getServerDisplayName(string $serverKey): string
-    {
-        $serverConfig = $this->serverConfigurationRegistry->getServerConfiguration($serverKey);
-        if ($serverConfig === null) {
-            return $serverKey . ' (Not found)';
-        }
-
-        return \sprintf('%s (%s)', $serverConfig['name'], $serverKey);
     }
 }

--- a/src/Command/DebugMcpPromptsCommand.php
+++ b/src/Command/DebugMcpPromptsCommand.php
@@ -7,6 +7,7 @@ namespace Ecourty\McpServerBundle\Command;
 use Ecourty\McpServerBundle\Prompt\Argument;
 use Ecourty\McpServerBundle\Prompt\PromptDefinition;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
+use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -28,6 +29,7 @@ class DebugMcpPromptsCommand extends Command
 {
     public function __construct(
         private readonly PromptRegistry $promptRegistry,
+        private readonly ServerConfigurationRegistry $serverConfigurationRegistry,
     ) {
         parent::__construct();
     }
@@ -61,12 +63,16 @@ class DebugMcpPromptsCommand extends Command
             return self::FAILURE;
         }
 
+        $serverKey = $this->promptRegistry->getPromptServerKey($promptName);
+        $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+
         $io->table(
-            ['Name', 'Description', 'Arguments'],
+            ['Name', 'Description', 'Server', 'Arguments'],
             [
                 [
                     $prompt->name,
                     $prompt->description,
+                    $serverInfo,
                     implode(', ', array_map(fn (Argument $argument) => $argument->name, $prompt->arguments ?? [])),
                 ],
             ],
@@ -88,16 +94,30 @@ class DebugMcpPromptsCommand extends Command
         }
 
         $io->table(
-            ['Name', 'Description', 'Arguments'],
-            array_map(static function (PromptDefinition $prompt) {
+            ['Name', 'Description', 'Server', 'Arguments'],
+            array_map(function (PromptDefinition $prompt) {
+                $serverKey = $this->promptRegistry->getPromptServerKey($prompt->name);
+                $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+
                 return [
                     $prompt->name,
                     $prompt->description,
+                    $serverInfo,
                     implode(', ', array_map(fn (Argument $argument) => $argument->name, $prompt->arguments ?? [])),
                 ];
             }, $promptsDefinitions),
         );
 
         return self::SUCCESS;
+    }
+
+    private function getServerDisplayName(string $serverKey): string
+    {
+        $serverConfig = $this->serverConfigurationRegistry->getServerConfiguration($serverKey);
+        if ($serverConfig === null) {
+            return $serverKey . ' (Not found)';
+        }
+
+        return \sprintf('%s (%s)', $serverConfig['name'], $serverKey);
     }
 }

--- a/src/Command/DebugMcpToolsCommand.php
+++ b/src/Command/DebugMcpToolsCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ecourty\McpServerBundle\Command;
 
-use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
 use Ecourty\McpServerBundle\Tool\ToolDefinition;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -29,7 +28,6 @@ class DebugMcpToolsCommand extends Command
 {
     public function __construct(
         private readonly ToolRegistry $toolRegistry,
-        private readonly ServerConfigurationRegistry $serverConfigurationRegistry,
     ) {
         parent::__construct();
     }
@@ -64,7 +62,7 @@ class DebugMcpToolsCommand extends Command
         }
 
         $serverKey = $this->toolRegistry->getToolServerKey($toolName);
-        $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+        $serverInfo = $serverKey ?? 'Global';
 
         $io->table(
             ['Name', 'Description', 'Server', 'Input Schema', 'Title', 'ReadOnly', 'Destructive', 'Idempotent', 'OpenWorld'],
@@ -102,7 +100,7 @@ class DebugMcpToolsCommand extends Command
             ['Name', 'Description', 'Server', 'Input Schema'],
             array_map(function (ToolDefinition $tool) {
                 $serverKey = $this->toolRegistry->getToolServerKey($tool->name);
-                $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+                $serverInfo = $serverKey ?? 'Global';
 
                 return [
                     $tool->name,
@@ -114,15 +112,5 @@ class DebugMcpToolsCommand extends Command
         );
 
         return self::SUCCESS;
-    }
-
-    private function getServerDisplayName(string $serverKey): string
-    {
-        $serverConfig = $this->serverConfigurationRegistry->getServerConfiguration($serverKey);
-        if ($serverConfig === null) {
-            return $serverKey . ' (Not found)';
-        }
-
-        return \sprintf('%s (%s)', $serverConfig['name'], $serverKey);
     }
 }

--- a/src/Command/DebugResourceCommand.php
+++ b/src/Command/DebugResourceCommand.php
@@ -6,7 +6,6 @@ namespace Ecourty\McpServerBundle\Command;
 
 use Ecourty\McpServerBundle\Resource\AbstractResourceDefinition;
 use Ecourty\McpServerBundle\Service\ResourceRegistry;
-use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -29,7 +28,6 @@ class DebugResourceCommand extends Command
 {
     public function __construct(
         private readonly ResourceRegistry $resourceRegistry,
-        private readonly ServerConfigurationRegistry $serverConfigurationRegistry,
     ) {
         parent::__construct();
     }
@@ -64,7 +62,7 @@ class DebugResourceCommand extends Command
         }
 
         $serverKey = $this->resourceRegistry->getResourceServerKey($resourceDefinition->uri);
-        $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+        $serverInfo = $serverKey ?? 'Global';
 
         $io->table(
             ['Name', 'URI', 'Server', 'Title', 'Description', 'MimeType', 'Size'],
@@ -100,7 +98,7 @@ class DebugResourceCommand extends Command
             ['Name', 'URI', 'Server', 'Title', 'Description', 'MimeType', 'Size'],
             array_map(function (AbstractResourceDefinition $resourceDefinition) {
                 $serverKey = $this->resourceRegistry->getResourceServerKey($resourceDefinition->uri);
-                $serverInfo = $serverKey ? $this->getServerDisplayName($serverKey) : 'Global (All servers)';
+                $serverInfo = $serverKey ?? 'Global';
 
                 return [
                     $resourceDefinition->name,
@@ -115,15 +113,5 @@ class DebugResourceCommand extends Command
         );
 
         return self::SUCCESS;
-    }
-
-    private function getServerDisplayName(string $serverKey): string
-    {
-        $serverConfig = $this->serverConfigurationRegistry->getServerConfiguration($serverKey);
-        if ($serverConfig === null) {
-            return $serverKey . ' (Not found)';
-        }
-
-        return \sprintf('%s (%s)', $serverConfig['name'], $serverKey);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,9 +13,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    private const string DEFAULT_NAME = 'MCP Server';
-    private const string DEFAULT_TITLE = self::DEFAULT_NAME;
-    private const string DEFAULT_VERSION = '1.0.0';
+    public const string DEFAULT_NAME = 'MCP Server';
+    public const string DEFAULT_TITLE = self::DEFAULT_NAME;
+    public const string DEFAULT_VERSION = '1.0.0';
 
     public function getConfigTreeBuilder(): TreeBuilder
     {
@@ -25,13 +25,68 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->getRootNode();
 
         $rootNode // @phpstan-ignore method.notFound
+            ->validate()
+                ->ifTrue(function ($config) {
+                    // Check that at least one of 'server' or 'servers' is defined
+                    $hasServer = isset($config['server']) && !empty($config['server']);
+                    $hasServers = isset($config['servers']) && !empty($config['servers']);
+
+                    return !$hasServer && !$hasServers;
+                })
+                ->then(function ($config) {
+                    // Default to single server configuration
+                    $config['server'] = [
+                        'name' => self::DEFAULT_NAME,
+                        'title' => self::DEFAULT_TITLE,
+                        'version' => self::DEFAULT_VERSION,
+                    ];
+
+                    return $config;
+                })
+            ->end()
+            ->validate()
+                ->always(function (array $config): array {
+                    // Automatically merge single server config into servers config
+                    $hasServer = isset($config['server']) && !empty($config['server']);
+                    $hasServers = isset($config['servers']) && !empty($config['servers']);
+
+                    if ($hasServer && $hasServers) {
+                        // Both are defined - merge server into servers as 'default' if not already present
+                        if (!isset($config['servers']['default'])) {
+                            $config['servers']['default'] = $config['server'];
+                        }
+                        // Remove the single server config since it's now in servers
+                        unset($config['server']);
+                    } elseif ($hasServer) {
+                        // Only single server or no servers - convert to servers config
+                        $config['servers'] = [
+                            'default' => $config['server'],
+                        ];
+                        unset($config['server']);
+                    }
+                    // If only servers config exists, leave it as-is
+
+                    return $config;
+                })
+            ->end()
             ->children()
                 ->arrayNode('server')
-                    ->addDefaultsIfNotSet()
+                    ->canBeUnset()
                     ->children()
                         ->scalarNode('name')->defaultValue(self::DEFAULT_NAME)->end()
                         ->scalarNode('title')->defaultValue(self::DEFAULT_TITLE)->end()
                         ->scalarNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
+                    ->end()
+                ->end()
+                ->arrayNode('servers')
+                    ->canBeUnset()
+                    ->useAttributeAsKey('key')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('name')->isRequired()->end()
+                            ->scalarNode('title')->end()
+                            ->scalarNode('version')->defaultValue(self::DEFAULT_VERSION)->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/McpServerBundleExtension.php
+++ b/src/DependencyInjection/McpServerBundleExtension.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Ecourty\McpServerBundle\DependencyInjection;
 
 use Ecourty\McpServerBundle\MethodHandler\InitializeMethodHandler;
+use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
@@ -32,16 +34,30 @@ class McpServerBundleExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
 
         /**
-         * @var array{server: array{name: string, title: string, version: string}} $config
+         * @var array{server?: array{name: string, title?: string, version: string}, servers?: array<string, array{name: string, title?: string, version: string}>} $config
          */
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.php');
 
+        // Transform configuration for ServerConfigurationRegistry
+        // After configuration processing, we always have a 'servers' array
+        $serverConfigurations = $config['servers'] ?? [];
+
+        // Register the ServerConfigurationRegistry with the server configurations
+        $serverConfigRegistryDefinition = new Definition(ServerConfigurationRegistry::class, [$serverConfigurations]);
+        $container->setDefinition(ServerConfigurationRegistry::class, $serverConfigRegistryDefinition);
+
+        // Store server configurations as a container parameter for compile-time validation
+        $container->setParameter('mcp_server.configured_servers', array_keys($serverConfigurations));
+
+        // Configure the InitializeMethodHandler to use the ServerConfigurationRegistry
+        // since we now always have multiple servers (even if just one)
         $container->getDefinition(InitializeMethodHandler::class)
-            ->setArgument('$serverName', $config['server']['name'])
-            ->setArgument('$serverTitle', $config['server']['title'])
-            ->setArgument('$serverVersion', $config['server']['version']);
+            ->setArgument('$serverConfigurationRegistry', $container->getDefinition(ServerConfigurationRegistry::class))
+            ->setArgument('$serverName', null)
+            ->setArgument('$serverTitle', null)
+            ->setArgument('$serverVersion', null);
     }
 }

--- a/src/MethodHandler/InitializeMethodHandler.php
+++ b/src/MethodHandler/InitializeMethodHandler.php
@@ -9,9 +9,9 @@ use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\DependencyInjection\Configuration;
 use Ecourty\McpServerBundle\Event\InitializeEvent;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'initialize' method for the MCP server.
@@ -30,7 +30,7 @@ class InitializeMethodHandler implements MethodHandlerInterface
         private readonly ?string $serverVersion = null,
         private readonly ?ServerConfigurationRegistry $serverConfigurationRegistry = null,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
-        private readonly ?RequestStack $requestStack = null,
+        private readonly ?CurrentServerService $currentServerService = null,
     ) {
     }
 
@@ -121,18 +121,12 @@ class InitializeMethodHandler implements MethodHandlerInterface
      */
     private function determineServerFromRequest(): ?array
     {
-        if ($this->requestStack === null || $this->serverConfigurationRegistry === null) {
+        if ($this->currentServerService === null || $this->serverConfigurationRegistry === null) {
             return null;
         }
 
-        $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest === null) {
-            return null;
-        }
-
-        // Get the serverKey from request attributes (set by the controller)
-        $serverKey = $currentRequest->attributes->get('serverKey');
-        if (!\is_string($serverKey)) {
+        $serverKey = $this->currentServerService->getCurrentServerKey();
+        if ($serverKey === null) {
             return null;
         }
 

--- a/src/MethodHandler/InitializeMethodHandler.php
+++ b/src/MethodHandler/InitializeMethodHandler.php
@@ -6,9 +6,12 @@ namespace Ecourty\McpServerBundle\MethodHandler;
 
 use Ecourty\McpServerBundle\Attribute\AsMethodHandler;
 use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
+use Ecourty\McpServerBundle\DependencyInjection\Configuration;
 use Ecourty\McpServerBundle\Event\InitializeEvent;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
+use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'initialize' method for the MCP server.
@@ -22,16 +25,21 @@ class InitializeMethodHandler implements MethodHandlerInterface
     public const string PROTOCOL_VERSION = '2025-06-18';
 
     public function __construct(
-        private readonly string $serverName,
-        private readonly string $serverTitle,
-        private readonly string $serverVersion,
+        private readonly ?string $serverName = null,
+        private readonly ?string $serverTitle = null,
+        private readonly ?string $serverVersion = null,
+        private readonly ?ServerConfigurationRegistry $serverConfigurationRegistry = null,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
+        private readonly ?RequestStack $requestStack = null,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
         $this->eventDispatcher?->dispatch(new InitializeEvent($request));
+
+        // Determine server info based on configuration type
+        $serverInfo = $this->getServerInfo();
 
         return [
             'protocolVersion' => self::PROTOCOL_VERSION,
@@ -47,11 +55,88 @@ class InitializeMethodHandler implements MethodHandlerInterface
                     'listChanged' => false,
                 ],
             ],
-            'serverInfo' => [
+            'serverInfo' => $serverInfo,
+        ];
+    }
+
+    /**
+     * @return array{name: string, title: string, version: string}
+     */
+    private function getServerInfo(): array
+    {
+        // If we have explicit server parameters (single server configuration)
+        if ($this->serverName !== null && $this->serverTitle !== null && $this->serverVersion !== null) {
+            return [
                 'name' => $this->serverName,
                 'title' => $this->serverTitle,
                 'version' => $this->serverVersion,
-            ],
+            ];
+        }
+
+        // If we have a server configuration registry (multiple servers configuration)
+        if ($this->serverConfigurationRegistry !== null) {
+            // Try to determine which server to use based on the serverKey in request attributes
+            $serverConfig = $this->determineServerFromRequest();
+            if ($serverConfig !== null) {
+                return [
+                    'name' => $serverConfig['name'],
+                    'title' => $serverConfig['title'] ?? $serverConfig['name'],
+                    'version' => $serverConfig['version'],
+                ];
+            }
+
+            // Fallback to "default" server if it exists
+            $defaultConfig = $this->serverConfigurationRegistry->getServerConfiguration('default');
+            if ($defaultConfig !== null) {
+                return [
+                    'name' => $defaultConfig['name'],
+                    'title' => $defaultConfig['title'] ?? $defaultConfig['name'],
+                    'version' => $defaultConfig['version'],
+                ];
+            }
+
+            // Fallback to first available server
+            $allConfigs = $this->serverConfigurationRegistry->getAllServerConfigurations();
+            if (!empty($allConfigs)) {
+                $firstConfig = reset($allConfigs);
+
+                return [
+                    'name' => $firstConfig['name'],
+                    'title' => $firstConfig['title'] ?? $firstConfig['name'],
+                    'version' => $firstConfig['version'],
+                ];
+            }
+        }
+
+        // Fallback values
+        return [
+            'name' => Configuration::DEFAULT_NAME,
+            'title' => Configuration::DEFAULT_TITLE,
+            'version' => Configuration::DEFAULT_VERSION,
         ];
+    }
+
+    /**
+     * @return array{name: string, title?: string, version: string}|null
+     */
+    private function determineServerFromRequest(): ?array
+    {
+        if ($this->requestStack === null || $this->serverConfigurationRegistry === null) {
+            return null;
+        }
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest === null) {
+            return null;
+        }
+
+        // Get the serverKey from request attributes (set by the controller)
+        $serverKey = $currentRequest->attributes->get('serverKey');
+        if (!\is_string($serverKey)) {
+            return null;
+        }
+
+        // Get the server configuration for this serverKey
+        return $this->serverConfigurationRegistry->getServerConfiguration($serverKey);
     }
 }

--- a/src/MethodHandler/PromptsGetMethodHandler.php
+++ b/src/MethodHandler/PromptsGetMethodHandler.php
@@ -14,6 +14,7 @@ use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
 use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
 use Ecourty\McpServerBundle\Prompt\PromptDefinition;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\InputSanitizer;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -32,6 +33,7 @@ class PromptsGetMethodHandler implements MethodHandlerInterface
     public function __construct(
         private readonly PromptRegistry $promptRegistry,
         private readonly InputSanitizer $inputSanitizer,
+        private readonly CurrentServerService $currentServerService,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {
     }
@@ -44,11 +46,12 @@ class PromptsGetMethodHandler implements MethodHandlerInterface
             throw new \InvalidArgumentException('Prompt name is required.');
         }
 
-        $prompt = $this->promptRegistry->getPrompt($promptName);
+        $serverKey = $this->currentServerService->getCurrentServerKey();
+        $prompt = $this->promptRegistry->getPrompt($promptName, $serverKey);
         $promptDefinition = $this->promptRegistry->getPromptDefinition($promptName);
 
         if ($prompt === null) {
-            throw new \InvalidArgumentException(\sprintf('Prompt "%s" not found.', $promptName));
+            throw new \InvalidArgumentException(\sprintf('Prompt "%s" not found or not available in current server context.', $promptName));
         }
 
         if ($promptDefinition === null) {

--- a/src/MethodHandler/PromptsListMethodHandler.php
+++ b/src/MethodHandler/PromptsListMethodHandler.php
@@ -7,8 +7,8 @@ namespace Ecourty\McpServerBundle\MethodHandler;
 use Ecourty\McpServerBundle\Attribute\AsMethodHandler;
 use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'prompts/list' method in the MCP server.
@@ -22,20 +22,13 @@ class PromptsListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly PromptRegistry $toolRegistry,
-        private readonly ?RequestStack $requestStack = null,
+        private readonly CurrentServerService $currentServerService,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
-        // Try to get the server key from the current request
-        $serverKey = null;
-        if ($this->requestStack !== null) {
-            $currentRequest = $this->requestStack->getCurrentRequest();
-            if ($currentRequest !== null) {
-                $serverKey = $currentRequest->attributes->get('serverKey');
-            }
-        }
+        $serverKey = $this->currentServerService->getCurrentServerKey();
 
         return [
             'prompts' => $this->toolRegistry->getPromptsDefinitions($serverKey),

--- a/src/MethodHandler/PromptsListMethodHandler.php
+++ b/src/MethodHandler/PromptsListMethodHandler.php
@@ -8,6 +8,7 @@ use Ecourty\McpServerBundle\Attribute\AsMethodHandler;
 use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'prompts/list' method in the MCP server.
@@ -21,13 +22,23 @@ class PromptsListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly PromptRegistry $toolRegistry,
+        private readonly ?RequestStack $requestStack = null,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
+        // Try to get the server key from the current request
+        $serverKey = null;
+        if ($this->requestStack !== null) {
+            $currentRequest = $this->requestStack->getCurrentRequest();
+            if ($currentRequest !== null) {
+                $serverKey = $currentRequest->attributes->get('serverKey');
+            }
+        }
+
         return [
-            'prompts' => $this->toolRegistry->getPromptsDefinitions(),
+            'prompts' => $this->toolRegistry->getPromptsDefinitions($serverKey),
         ];
     }
 }

--- a/src/MethodHandler/ResourcesListMethodHandler.php
+++ b/src/MethodHandler/ResourcesListMethodHandler.php
@@ -10,6 +10,7 @@ use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\Resource\AbstractResourceDefinition;
 use Ecourty\McpServerBundle\Resource\DirectResourceDefinition;
 use Ecourty\McpServerBundle\Service\ResourceRegistry;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'resources/list' method in the MCP server.
@@ -25,12 +26,22 @@ class ResourcesListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ResourceRegistry $resourceRegistry,
+        private readonly ?RequestStack $requestStack = null,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
-        $resourceDefinitions = $this->resourceRegistry->getResourceDefinitions();
+        // Try to get the server key from the current request
+        $serverKey = null;
+        if ($this->requestStack !== null) {
+            $currentRequest = $this->requestStack->getCurrentRequest();
+            if ($currentRequest !== null) {
+                $serverKey = $currentRequest->attributes->get('serverKey');
+            }
+        }
+
+        $resourceDefinitions = $this->resourceRegistry->getResourceDefinitions($serverKey);
         /** @var DirectResourceDefinition[] $directResourcesDefinitions */
         $directResourcesDefinitions = array_filter($resourceDefinitions, function (AbstractResourceDefinition $definition) {
             return $definition instanceof DirectResourceDefinition;

--- a/src/MethodHandler/ResourcesListMethodHandler.php
+++ b/src/MethodHandler/ResourcesListMethodHandler.php
@@ -9,8 +9,8 @@ use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\Resource\AbstractResourceDefinition;
 use Ecourty\McpServerBundle\Resource\DirectResourceDefinition;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ResourceRegistry;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'resources/list' method in the MCP server.
@@ -26,20 +26,13 @@ class ResourcesListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ResourceRegistry $resourceRegistry,
-        private readonly ?RequestStack $requestStack = null,
+        private readonly CurrentServerService $currentServerService,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
-        // Try to get the server key from the current request
-        $serverKey = null;
-        if ($this->requestStack !== null) {
-            $currentRequest = $this->requestStack->getCurrentRequest();
-            if ($currentRequest !== null) {
-                $serverKey = $currentRequest->attributes->get('serverKey');
-            }
-        }
+        $serverKey = $this->currentServerService->getCurrentServerKey();
 
         $resourceDefinitions = $this->resourceRegistry->getResourceDefinitions($serverKey);
         /** @var DirectResourceDefinition[] $directResourcesDefinitions */

--- a/src/MethodHandler/ResourcesReadMethodHandler.php
+++ b/src/MethodHandler/ResourcesReadMethodHandler.php
@@ -9,6 +9,7 @@ use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\Event\Resource\ResourceReadEvent;
 use Ecourty\McpServerBundle\Event\Resource\ResourceReadResultEvent;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ResourceExecutor;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
@@ -26,6 +27,7 @@ class ResourcesReadMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ResourceExecutor $resourceExecutor,
+        private readonly CurrentServerService $currentServerService,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {
     }
@@ -40,7 +42,8 @@ class ResourcesReadMethodHandler implements MethodHandlerInterface
 
         $this->eventDispatcher?->dispatch(new ResourceReadEvent($uri));
 
-        $result = $this->resourceExecutor->execute($uri);
+        $serverKey = $this->currentServerService->getCurrentServerKey();
+        $result = $this->resourceExecutor->execute($uri, $serverKey);
 
         $this->eventDispatcher?->dispatch(new ResourceReadResultEvent($uri, $result));
 

--- a/src/MethodHandler/ResourcesTemplatesListMethodHandler.php
+++ b/src/MethodHandler/ResourcesTemplatesListMethodHandler.php
@@ -9,8 +9,8 @@ use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\Resource\AbstractResourceDefinition;
 use Ecourty\McpServerBundle\Resource\TemplateResourceDefinition;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ResourceRegistry;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'resources/templates/list' method in the MCP server.
@@ -26,20 +26,13 @@ class ResourcesTemplatesListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ResourceRegistry $resourceRegistry,
-        private readonly ?RequestStack $requestStack = null,
+        private readonly CurrentServerService $currentServerService,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
-        // Try to get the server key from the current request
-        $serverKey = null;
-        if ($this->requestStack !== null) {
-            $currentRequest = $this->requestStack->getCurrentRequest();
-            if ($currentRequest !== null) {
-                $serverKey = $currentRequest->attributes->get('serverKey');
-            }
-        }
+        $serverKey = $this->currentServerService->getCurrentServerKey();
 
         $resourceDefinitions = $this->resourceRegistry->getResourceDefinitions($serverKey);
         /** @var TemplateResourceDefinition[] $templateDefinitions */

--- a/src/MethodHandler/ToolsCallMethodHandler.php
+++ b/src/MethodHandler/ToolsCallMethodHandler.php
@@ -12,6 +12,7 @@ use Ecourty\McpServerBundle\Event\ToolResultEvent;
 use Ecourty\McpServerBundle\Exception\ToolCallException;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\IO\ToolResult;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\InputSanitizer;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -37,6 +38,7 @@ class ToolsCallMethodHandler implements MethodHandlerInterface
         private readonly SerializerInterface $serializer,
         private readonly ValidatorInterface $validator,
         private readonly InputSanitizer $inputSanitizer,
+        private readonly CurrentServerService $currentServerService,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {
     }
@@ -49,11 +51,12 @@ class ToolsCallMethodHandler implements MethodHandlerInterface
             throw new \InvalidArgumentException('Tool name is required.');
         }
 
-        $tool = $this->toolRegistry->getTool($toolName);
+        $serverKey = $this->currentServerService->getCurrentServerKey();
+        $tool = $this->toolRegistry->getTool($toolName, $serverKey);
         $toolDefinition = $this->toolRegistry->getToolDefinition($toolName);
 
         if ($tool === null) {
-            throw new \InvalidArgumentException(\sprintf('Tool "%s" not found.', $request->params['name']));
+            throw new \InvalidArgumentException(\sprintf('Tool "%s" not found or not available in current server context.', $toolName));
         }
 
         if ($toolDefinition === null) {

--- a/src/MethodHandler/ToolsListMethodHandler.php
+++ b/src/MethodHandler/ToolsListMethodHandler.php
@@ -8,6 +8,7 @@ use Ecourty\McpServerBundle\Attribute\AsMethodHandler;
 use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'tools/list' method in the MCP server.
@@ -22,13 +23,23 @@ class ToolsListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ToolRegistry $toolRegistry,
+        private readonly ?RequestStack $requestStack = null,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
+        // Try to get the server key from the current request
+        $serverKey = null;
+        if ($this->requestStack !== null) {
+            $currentRequest = $this->requestStack->getCurrentRequest();
+            if ($currentRequest !== null) {
+                $serverKey = $currentRequest->attributes->get('serverKey');
+            }
+        }
+
         return [
-            'tools' => $this->toolRegistry->getToolsDefinitions(),
+            'tools' => $this->toolRegistry->getToolsDefinitions($serverKey),
         ];
     }
 }

--- a/src/MethodHandler/ToolsListMethodHandler.php
+++ b/src/MethodHandler/ToolsListMethodHandler.php
@@ -7,8 +7,8 @@ namespace Ecourty\McpServerBundle\MethodHandler;
 use Ecourty\McpServerBundle\Attribute\AsMethodHandler;
 use Ecourty\McpServerBundle\Contract\MethodHandlerInterface;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Handles the 'tools/list' method in the MCP server.
@@ -23,20 +23,13 @@ class ToolsListMethodHandler implements MethodHandlerInterface
 {
     public function __construct(
         private readonly ToolRegistry $toolRegistry,
-        private readonly ?RequestStack $requestStack = null,
+        private readonly CurrentServerService $currentServerService,
     ) {
     }
 
     public function handle(JsonRpcRequest $request): array
     {
-        // Try to get the server key from the current request
-        $serverKey = null;
-        if ($this->requestStack !== null) {
-            $currentRequest = $this->requestStack->getCurrentRequest();
-            if ($currentRequest !== null) {
-                $serverKey = $currentRequest->attributes->get('serverKey');
-            }
-        }
+        $serverKey = $this->currentServerService->getCurrentServerKey();
 
         return [
             'tools' => $this->toolRegistry->getToolsDefinitions($serverKey),

--- a/src/Service/CurrentServerService.php
+++ b/src/Service/CurrentServerService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Service;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Service to extract the current server key from the request context.
+ *
+ * This service centralizes the logic for retrieving the server key that is set
+ * by the routing system when handling multi-server MCP requests.
+ */
+class CurrentServerService
+{
+    public function __construct(
+        private readonly ?RequestStack $requestStack = null,
+    ) {
+    }
+
+    /**
+     * Get the current server key from the request attributes.
+     *
+     * Returns the server key if available in the current request context,
+     * or null if no request is available or no server key is set.
+     */
+    public function getCurrentServerKey(): ?string
+    {
+        if ($this->requestStack === null) {
+            return null;
+        }
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest === null) {
+            return null;
+        }
+
+        $serverKey = $currentRequest->attributes->get('serverKey');
+
+        return \is_string($serverKey) ? $serverKey : null;
+    }
+}

--- a/src/Service/PromptRegistry.php
+++ b/src/Service/PromptRegistry.php
@@ -31,10 +31,20 @@ class PromptRegistry
     ) {
     }
 
-    public function getPrompt(string $name): ?object
+    public function getPrompt(string $name, ?string $serverKey = null): ?object
     {
         if ($this->promptLocator->has($name) === false) {
             return null;
+        }
+
+        // If server key is provided, validate that the prompt belongs to this server
+        if ($serverKey !== null) {
+            $promptServerKey = $this->promptToServerMapping[$name] ?? null;
+
+            // Allow access to prompts with no server key (global prompts) or prompts that belong to the current server
+            if ($promptServerKey !== null && $promptServerKey !== $serverKey) {
+                return null;
+            }
         }
 
         return $this->promptLocator->get($name);

--- a/src/Service/ResourceExecutor.php
+++ b/src/Service/ResourceExecutor.php
@@ -18,10 +18,10 @@ class ResourceExecutor
     ) {
     }
 
-    public function execute(string $uri): ResourceResult
+    public function execute(string $uri, ?string $serverKey = null): ResourceResult
     {
-        $definition = $this->findDefinition($uri);
-        $resource = $this->getResourceInstance($definition->uri);
+        $definition = $this->findDefinition($uri, $serverKey);
+        $resource = $this->getResourceInstance($definition->uri, $serverKey);
         $invokeMethod = $this->getInvokeMethod($resource, $definition->uri);
 
         $rawArgs = $this->matcher->match($definition->uri, $uri);
@@ -40,9 +40,9 @@ class ResourceExecutor
         return $result;
     }
 
-    private function findDefinition(string $uri): AbstractResourceDefinition
+    private function findDefinition(string $uri, ?string $serverKey = null): AbstractResourceDefinition
     {
-        $resourceDefinitions = $this->registry->getResourceDefinitions();
+        $resourceDefinitions = $this->registry->getResourceDefinitions($serverKey);
 
         foreach ($resourceDefinitions as $resourceDefinition) {
             $matchResult = $this->matcher->match($resourceDefinition->uri, $uri);
@@ -55,18 +55,18 @@ class ResourceExecutor
         }
 
         throw new \InvalidArgumentException(\sprintf(
-            'No resource matched URI "%s".',
+            'No resource matched URI "%s" or resource not available in current server context.',
             $uri,
         ));
     }
 
-    private function getResourceInstance(string $resourceUri): object
+    private function getResourceInstance(string $resourceUri, ?string $serverKey = null): object
     {
-        $resource = $this->registry->getResource($resourceUri);
+        $resource = $this->registry->getResource($resourceUri, $serverKey);
 
         if ($resource === null) {
             throw new \RuntimeException(\sprintf(
-                'Resource "%s" not found.',
+                'Resource "%s" not found or not available in current server context.',
                 $resourceUri,
             ));
         }

--- a/src/Service/ResourceRegistry.php
+++ b/src/Service/ResourceRegistry.php
@@ -32,10 +32,20 @@ class ResourceRegistry
     ) {
     }
 
-    public function getResource(string $uri): ?object
+    public function getResource(string $uri, ?string $serverKey = null): ?object
     {
         if ($this->resourceLocator->has($uri) === false) {
             return null;
+        }
+
+        // If server key is provided, validate that the resource belongs to this server
+        if ($serverKey !== null) {
+            $resourceServerKey = $this->resourceToServerMapping[$uri] ?? null;
+
+            // Allow access to resources with no server key (global resources) or resources that belong to the current server
+            if ($resourceServerKey !== null && $resourceServerKey !== $serverKey) {
+                return null;
+            }
         }
 
         return $this->resourceLocator->get($uri);

--- a/src/Service/ServerConfigurationRegistry.php
+++ b/src/Service/ServerConfigurationRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Service;
+
+/**
+ * Registry for managing server configurations.
+ */
+class ServerConfigurationRegistry
+{
+    /**
+     * @param array<string, array{name: string, title?: string, version: string}> $serverConfigurations
+     */
+    public function __construct(
+        private readonly array $serverConfigurations,
+    ) {
+    }
+
+    /**
+     * Get all server configurations.
+     *
+     * @return array<string, array{name: string, title?: string, version: string}>
+     */
+    public function getAllServerConfigurations(): array
+    {
+        return $this->serverConfigurations;
+    }
+
+    /**
+     * Get a specific server configuration by key.
+     *
+     * @return array{name: string, title?: string, version: string}|null
+     */
+    public function getServerConfiguration(string $serverKey): ?array
+    {
+        return $this->serverConfigurations[$serverKey] ?? null;
+    }
+
+    /**
+     * Check if a server exists.
+     */
+    public function hasServer(string $serverKey): bool
+    {
+        return isset($this->serverConfigurations[$serverKey]);
+    }
+
+    /**
+     * Get all server keys.
+     *
+     * @return string[]
+     */
+    public function getServerKeys(): array
+    {
+        return array_keys($this->serverConfigurations);
+    }
+}

--- a/src/Service/ToolRegistry.php
+++ b/src/Service/ToolRegistry.php
@@ -30,10 +30,20 @@ class ToolRegistry
     ) {
     }
 
-    public function getTool(string $name): ?object
+    public function getTool(string $name, ?string $serverKey = null): ?object
     {
         if ($this->toolLocator->has($name) === false) {
             return null;
+        }
+
+        // If server key is provided, validate that the tool belongs to this server
+        if ($serverKey !== null) {
+            $toolServerKey = $this->toolToServerMapping[$name] ?? null;
+
+            // Allow access to tools with no server key (global tools) or tools that belong to the current server
+            if ($toolServerKey !== null && $toolServerKey !== $serverKey) {
+                return null;
+            }
         }
 
         return $this->toolLocator->get($name);

--- a/tests/Controller/EntrypointControllerTest.php
+++ b/tests/Controller/EntrypointControllerTest.php
@@ -105,7 +105,7 @@ class EntrypointControllerTest extends WebTestCase
         $this->assertArrayNotHasKey('isError', $resultContent);
 
         $this->assertArrayHasKey('tools', $resultContent);
-        $this->assertCount(4, $resultContent['tools']);
+        $this->assertCount(6, $resultContent['tools']);
 
         $tools = $resultContent['tools'];
 
@@ -118,8 +118,14 @@ class EntrypointControllerTest extends WebTestCase
         $this->assertSame('multiply_numbers', $tools[2]['name']);
         $this->assertSame('Calculates the product of two numbers', $tools[2]['description']);
 
-        $this->assertSame('sum_numbers', $tools[3]['name']);
-        $this->assertSame('Calculates the sum of two numbers', $tools[3]['description']);
+        $this->assertSame('server_a_tool', $tools[3]['name']);
+        $this->assertSame('Tool only available on server A', $tools[3]['description']);
+
+        $this->assertSame('server_b_tool', $tools[4]['name']);
+        $this->assertSame('Tool only available on server B', $tools[4]['description']);
+
+        $this->assertSame('sum_numbers', $tools[5]['name']);
+        $this->assertSame('Calculates the sum of two numbers', $tools[5]['description']);
 
         $this->assertArrayHasKey('inputSchema', $tools[0]);
         $this->assertSame([
@@ -400,7 +406,7 @@ class EntrypointControllerTest extends WebTestCase
         $resultContent = $responseContent['result'];
 
         $this->assertArrayHasKey('prompts', $resultContent);
-        $this->assertCount(3, $resultContent['prompts']);
+        $this->assertCount(5, $resultContent['prompts']);
 
         $prompts = $resultContent['prompts'];
 
@@ -426,6 +432,16 @@ class EntrypointControllerTest extends WebTestCase
         $this->assertSame('say_hello', $prompts[2]['name']);
         $this->assertSame('Says hello', $prompts[2]['description']);
         $this->assertArrayNotHasKey('arguments', $prompts[2]);
+
+        $this->assertSame('server-a-prompt', $prompts[3]['name']);
+        $this->assertSame('Prompt only available on server A', $prompts[3]['description']);
+        $this->assertArrayHasKey('arguments', $prompts[3]);
+        $this->assertCount(1, $prompts[3]['arguments']);
+
+        $this->assertSame('server-b-prompt', $prompts[4]['name']);
+        $this->assertSame('Prompt only available on server B', $prompts[4]['description']);
+        $this->assertArrayHasKey('arguments', $prompts[4]);
+        $this->assertCount(1, $prompts[4]['arguments']);
     }
 
     public function testPromptGet(): void

--- a/tests/DependencyInjection/CompilerPass/PromptPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/PromptPassTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Tests\DependencyInjection\CompilerPass;
+
+use Ecourty\McpServerBundle\Attribute\AsPrompt;
+use Ecourty\McpServerBundle\DependencyInjection\CompilerPass\PromptPass;
+use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
+use Ecourty\McpServerBundle\Service\PromptRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class PromptPassTest extends TestCase
+{
+    public function testProcessWithValidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $promptRegistryDefinition = new Definition(PromptRegistry::class);
+        $container->setDefinition(PromptRegistry::class, $promptRegistryDefinition);
+
+        $promptDefinition = new Definition(ValidPrompt::class);
+        $container->setDefinition('test.prompt', $promptDefinition);
+
+        $pass = new PromptPass();
+
+        // Should not throw an exception
+        $pass->process($container);
+
+        $this->assertTrue($promptDefinition->hasTag('mcp_server.prompt'));
+        $this->assertCount(1, $promptRegistryDefinition->getMethodCalls());
+    }
+
+    public function testProcessWithInvalidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $promptRegistryDefinition = new Definition(PromptRegistry::class);
+        $container->setDefinition(PromptRegistry::class, $promptRegistryDefinition);
+
+        $promptDefinition = new Definition(InvalidServerPrompt::class);
+        $container->setDefinition('test.prompt', $promptDefinition);
+
+        $pass = new PromptPass();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Prompt "test-prompt" references server "invalid_server" which is not configured. Available servers: server_a, server_b');
+
+        $pass->process($container);
+    }
+
+    public function testProcessWithNullServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $promptRegistryDefinition = new Definition(PromptRegistry::class);
+        $container->setDefinition(PromptRegistry::class, $promptRegistryDefinition);
+
+        $promptDefinition = new Definition(NullServerPrompt::class);
+        $container->setDefinition('test.prompt', $promptDefinition);
+
+        $pass = new PromptPass();
+
+        // Should not throw an exception for null server
+        $pass->process($container);
+
+        $this->assertTrue($promptDefinition->hasTag('mcp_server.prompt'));
+        $this->assertCount(1, $promptRegistryDefinition->getMethodCalls());
+    }
+}
+
+#[AsPrompt(
+    name: 'test-prompt',
+    description: 'A test prompt',
+    server: 'server_a',
+)]
+class ValidPrompt
+{
+    public function __invoke(): PromptResult
+    {
+        return new PromptResult('Test prompt content');
+    }
+}
+
+#[AsPrompt(
+    name: 'test-prompt',
+    description: 'A test prompt',
+    server: 'invalid_server',
+)]
+class InvalidServerPrompt
+{
+    public function __invoke(): PromptResult
+    {
+        return new PromptResult('Test prompt content');
+    }
+}
+
+#[AsPrompt(
+    name: 'test-prompt',
+    description: 'A test prompt',
+    server: null,
+)]
+class NullServerPrompt
+{
+    public function __invoke(): PromptResult
+    {
+        return new PromptResult('Test prompt content');
+    }
+}

--- a/tests/DependencyInjection/CompilerPass/ResourcePassTest.php
+++ b/tests/DependencyInjection/CompilerPass/ResourcePassTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Tests\DependencyInjection\CompilerPass;
+
+use Ecourty\McpServerBundle\Attribute\AsResource;
+use Ecourty\McpServerBundle\DependencyInjection\CompilerPass\ResourcePass;
+use Ecourty\McpServerBundle\IO\Resource\ResourceResult;
+use Ecourty\McpServerBundle\Service\ResourceRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ResourcePassTest extends TestCase
+{
+    public function testProcessWithValidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $resourceRegistryDefinition = new Definition(ResourceRegistry::class);
+        $container->setDefinition(ResourceRegistry::class, $resourceRegistryDefinition);
+
+        $resourceDefinition = new Definition(ValidResource::class);
+        $container->setDefinition('test.resource', $resourceDefinition);
+
+        $pass = new ResourcePass();
+
+        // Should not throw an exception
+        $pass->process($container);
+
+        $this->assertTrue($resourceDefinition->hasTag('mcp_server.resource'));
+        $this->assertCount(1, $resourceRegistryDefinition->getMethodCalls());
+    }
+
+    public function testProcessWithInvalidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $resourceRegistryDefinition = new Definition(ResourceRegistry::class);
+        $container->setDefinition(ResourceRegistry::class, $resourceRegistryDefinition);
+
+        $resourceDefinition = new Definition(InvalidServerResource::class);
+        $container->setDefinition('test.resource', $resourceDefinition);
+
+        $pass = new ResourcePass();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Resource "test-resource" references server "invalid_server" which is not configured. Available servers: server_a, server_b');
+
+        $pass->process($container);
+    }
+
+    public function testProcessWithNullServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $resourceRegistryDefinition = new Definition(ResourceRegistry::class);
+        $container->setDefinition(ResourceRegistry::class, $resourceRegistryDefinition);
+
+        $resourceDefinition = new Definition(NullServerResource::class);
+        $container->setDefinition('test.resource', $resourceDefinition);
+
+        $pass = new ResourcePass();
+
+        // Should not throw an exception for null server
+        $pass->process($container);
+
+        $this->assertTrue($resourceDefinition->hasTag('mcp_server.resource'));
+        $this->assertCount(1, $resourceRegistryDefinition->getMethodCalls());
+    }
+}
+
+#[AsResource(
+    name: 'test-resource',
+    uri: 'test://resource',
+    title: 'Test Resource',
+    description: 'A test resource',
+    server: 'server_a',
+)]
+class ValidResource
+{
+    public function __invoke(): ResourceResult
+    {
+        return new ResourceResult([]);
+    }
+}
+
+#[AsResource(
+    name: 'test-resource',
+    uri: 'test://resource',
+    title: 'Test Resource',
+    description: 'A test resource',
+    server: 'invalid_server',
+)]
+class InvalidServerResource
+{
+    public function __invoke(): ResourceResult
+    {
+        return new ResourceResult([]);
+    }
+}
+
+#[AsResource(
+    name: 'test-resource',
+    uri: 'test://resource',
+    title: 'Test Resource',
+    description: 'A test resource',
+    server: null,
+)]
+class NullServerResource
+{
+    public function __invoke(): ResourceResult
+    {
+        return new ResourceResult([]);
+    }
+}

--- a/tests/DependencyInjection/CompilerPass/ToolPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/ToolPassTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Tests\DependencyInjection\CompilerPass;
+
+use Ecourty\McpServerBundle\Attribute\AsTool;
+use Ecourty\McpServerBundle\DependencyInjection\CompilerPass\ToolPass;
+use Ecourty\McpServerBundle\IO\ToolResult;
+use Ecourty\McpServerBundle\Service\ToolRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ToolPassTest extends TestCase
+{
+    public function testProcessWithValidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $toolRegistryDefinition = new Definition(ToolRegistry::class);
+        $container->setDefinition(ToolRegistry::class, $toolRegistryDefinition);
+
+        $toolDefinition = new Definition(ValidTool::class);
+        $container->setDefinition('test.tool', $toolDefinition);
+
+        $pass = new ToolPass();
+
+        // Should not throw an exception
+        $pass->process($container);
+
+        $this->assertTrue($toolDefinition->hasTag('mcp_server.tool'));
+        $this->assertCount(1, $toolRegistryDefinition->getMethodCalls());
+    }
+
+    public function testProcessWithInvalidServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $toolRegistryDefinition = new Definition(ToolRegistry::class);
+        $container->setDefinition(ToolRegistry::class, $toolRegistryDefinition);
+
+        $toolDefinition = new Definition(InvalidServerTool::class);
+        $container->setDefinition('test.tool', $toolDefinition);
+
+        $pass = new ToolPass();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Tool "test-tool" references server "invalid_server" which is not configured. Available servers: server_a, server_b');
+
+        $pass->process($container);
+    }
+
+    public function testProcessWithNullServerConfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('mcp_server.configured_servers', ['server_a', 'server_b']);
+
+        $toolRegistryDefinition = new Definition(ToolRegistry::class);
+        $container->setDefinition(ToolRegistry::class, $toolRegistryDefinition);
+
+        $toolDefinition = new Definition(NullServerTool::class);
+        $container->setDefinition('test.tool', $toolDefinition);
+
+        $pass = new ToolPass();
+
+        // Should not throw an exception for null server
+        $pass->process($container);
+
+        $this->assertTrue($toolDefinition->hasTag('mcp_server.tool'));
+        $this->assertCount(1, $toolRegistryDefinition->getMethodCalls());
+    }
+}
+
+#[AsTool(
+    name: 'test-tool',
+    description: 'A test tool',
+    server: 'server_a',
+)]
+class ValidTool
+{
+    public function __invoke(): ToolResult
+    {
+        return new ToolResult([]);
+    }
+}
+
+#[AsTool(
+    name: 'test-tool',
+    description: 'A test tool',
+    server: 'invalid_server',
+)]
+class InvalidServerTool
+{
+    public function __invoke(): ToolResult
+    {
+        return new ToolResult([]);
+    }
+}
+
+#[AsTool(
+    name: 'test-tool',
+    description: 'A test tool',
+    server: null,
+)]
+class NullServerTool
+{
+    public function __invoke(): ToolResult
+    {
+        return new ToolResult([]);
+    }
+}

--- a/tests/MethodHandler/PromptsGetMethodHandlerTest.php
+++ b/tests/MethodHandler/PromptsGetMethodHandlerTest.php
@@ -11,6 +11,7 @@ use Ecourty\McpServerBundle\Event\Prompt\PromptResultEvent;
 use Ecourty\McpServerBundle\Exception\PromptGetException;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\MethodHandler\PromptsGetMethodHandler;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\InputSanitizer;
 use Ecourty\McpServerBundle\Service\PromptRegistry;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -35,10 +36,13 @@ class PromptsGetMethodHandlerTest extends KernelTestCase
         $promptRegistry = self::getContainer()->get(PromptRegistry::class);
         /** @var InputSanitizer $inputSanitizer */
         $inputSanitizer = self::getContainer()->get(InputSanitizer::class);
+        /** @var CurrentServerService $currentServerService */
+        $currentServerService = self::getContainer()->get(CurrentServerService::class);
 
         $this->promptsGetMethodHandler = new PromptsGetMethodHandler(
             promptRegistry: $promptRegistry,
             inputSanitizer: $inputSanitizer,
+            currentServerService: $currentServerService,
             eventDispatcher: $this->eventDispatcher,
         );
     }

--- a/tests/MethodHandler/ResourcesReadMethodHandlerTest.php
+++ b/tests/MethodHandler/ResourcesReadMethodHandlerTest.php
@@ -11,6 +11,7 @@ use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\IO\Resource\BinaryResource;
 use Ecourty\McpServerBundle\IO\Resource\ResourceResult;
 use Ecourty\McpServerBundle\MethodHandler\ResourcesReadMethodHandler;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\ResourceExecutor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +23,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 class ResourcesReadMethodHandlerTest extends TestCase
 {
     private MockObject&ResourceExecutor $resourceExecutor;
+    private MockObject&CurrentServerService $currentServerService;
     private MockObject&EventDispatcherInterface $eventDispatcher;
 
     private ResourcesReadMethodHandler $handler;
@@ -29,10 +31,12 @@ class ResourcesReadMethodHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->resourceExecutor = $this->createMock(ResourceExecutor::class);
+        $this->currentServerService = $this->createMock(CurrentServerService::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->handler = new ResourcesReadMethodHandler(
             resourceExecutor: $this->resourceExecutor,
+            currentServerService: $this->currentServerService,
             eventDispatcher: $this->eventDispatcher,
         );
     }
@@ -61,9 +65,17 @@ class ResourcesReadMethodHandlerTest extends TestCase
                 blob: 'blob_data',
             ),
         ]);
+
+        $serverKey = 'test_server';
+        $this->currentServerService
+            ->expects($this->once())
+            ->method('getCurrentServerKey')
+            ->willReturn($serverKey);
+
         $this->resourceExecutor
             ->expects($this->once())
             ->method('execute')
+            ->with('file://random', $serverKey)
             ->willReturn($resourceResult);
 
         $uri = 'file://random';

--- a/tests/MethodHandler/ToolsCallMethodHandlerTest.php
+++ b/tests/MethodHandler/ToolsCallMethodHandlerTest.php
@@ -9,6 +9,7 @@ use Ecourty\McpServerBundle\Event\ToolCallEvent;
 use Ecourty\McpServerBundle\Event\ToolResultEvent;
 use Ecourty\McpServerBundle\HttpFoundation\JsonRpcRequest;
 use Ecourty\McpServerBundle\MethodHandler\ToolsCallMethodHandler;
+use Ecourty\McpServerBundle\Service\CurrentServerService;
 use Ecourty\McpServerBundle\Service\InputSanitizer;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -39,12 +40,15 @@ class ToolsCallMethodHandlerTest extends KernelTestCase
         $validator = self::getContainer()->get(ValidatorInterface::class);
         /** @var InputSanitizer $inputSanitizer */
         $inputSanitizer = self::getContainer()->get(InputSanitizer::class);
+        /** @var CurrentServerService $currentServerService */
+        $currentServerService = self::getContainer()->get(CurrentServerService::class);
 
         $this->toolsCallMethodHandler = new ToolsCallMethodHandler(
             toolRegistry: $toolRegistry,
             serializer: $serializer,
             validator: $validator,
             inputSanitizer: $inputSanitizer,
+            currentServerService: $currentServerService,
             eventDispatcher: $this->eventDispatcher,
         );
     }

--- a/tests/Service/PromptRegistryTest.php
+++ b/tests/Service/PromptRegistryTest.php
@@ -150,6 +150,28 @@ class PromptRegistryTest extends KernelTestCase
     }
 
     /**
+     * @covers ::getPrompt
+     */
+    public function testGetPromptWithServerKey(): void
+    {
+        // Test getting a global prompt with any server key - should work
+        $globalPrompt = $this->registry->getPrompt('generate-git-commit-message', 'server_a');
+        $this->assertInstanceOf(GenerateGitCommitMessage::class, $globalPrompt);
+
+        // Test getting a server-specific prompt with correct server key - should work
+        $serverAPrompt = $this->registry->getPrompt('server-a-prompt', 'server_a');
+        $this->assertInstanceOf(ServerAPrompt::class, $serverAPrompt);
+
+        // Test getting a server-specific prompt with wrong server key - should return null
+        $wrongServerPrompt = $this->registry->getPrompt('server-a-prompt', 'server_b');
+        $this->assertNull($wrongServerPrompt);
+
+        // Test getting a server-specific prompt with no server key - should work (backwards compatibility)
+        $noServerPrompt = $this->registry->getPrompt('server-a-prompt');
+        $this->assertInstanceOf(ServerAPrompt::class, $noServerPrompt);
+    }
+
+    /**
      * @covers ::getPromptServerKey
      */
     #[DataProvider('providePromptServerKeyData')]

--- a/tests/Service/ServerConfigurationRegistryTest.php
+++ b/tests/Service/ServerConfigurationRegistryTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\Tests\Service;
+
+use Ecourty\McpServerBundle\Service\ServerConfigurationRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Ecourty\McpServerBundle\Service\ServerConfigurationRegistry
+ */
+class ServerConfigurationRegistryTest extends TestCase
+{
+    private ServerConfigurationRegistry $registry;
+
+    protected function setUp(): void
+    {
+        // Set up test data representing different server configurations
+        $serverConfigurations = [
+            'default' => [
+                'name' => 'Default Server',
+                'title' => 'Default MCP Server',
+                'version' => '1.0.0',
+            ],
+            'simple_rest' => [
+                'name' => 'Simple REST API Server',
+                'title' => 'Pimcore Data Hub Simple REST API',
+                'version' => '2.1.0',
+            ],
+            'analytics' => [
+                'name' => 'Analytics Server',
+                'version' => '1.5.0',
+                // Note: no title provided to test optional field
+            ],
+        ];
+
+        $this->registry = new ServerConfigurationRegistry($serverConfigurations);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getAllServerConfigurations
+     */
+    public function testGetAllServerConfigurations(): void
+    {
+        $expected = [
+            'default' => [
+                'name' => 'Default Server',
+                'title' => 'Default MCP Server',
+                'version' => '1.0.0',
+            ],
+            'simple_rest' => [
+                'name' => 'Simple REST API Server',
+                'title' => 'Pimcore Data Hub Simple REST API',
+                'version' => '2.1.0',
+            ],
+            'analytics' => [
+                'name' => 'Analytics Server',
+                'version' => '1.5.0',
+            ],
+        ];
+
+        $result = $this->registry->getAllServerConfigurations();
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @covers ::getServerConfiguration
+     *
+     * @param array{name: string, title?: string, version: string}|null $expected
+     */
+    #[DataProvider('provideServerConfigurationData')]
+    public function testGetServerConfiguration(string $serverKey, ?array $expected): void
+    {
+        $result = $this->registry->getServerConfiguration($serverKey);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: array{name: string, title?: string, version: string}|null}>
+     */
+    public static function provideServerConfigurationData(): array
+    {
+        return [
+            'existing server with title' => [
+                'default',
+                [
+                    'name' => 'Default Server',
+                    'title' => 'Default MCP Server',
+                    'version' => '1.0.0',
+                ],
+            ],
+            'existing server without title' => [
+                'analytics',
+                [
+                    'name' => 'Analytics Server',
+                    'version' => '1.5.0',
+                ],
+            ],
+            'existing server with all fields' => [
+                'simple_rest',
+                [
+                    'name' => 'Simple REST API Server',
+                    'title' => 'Pimcore Data Hub Simple REST API',
+                    'version' => '2.1.0',
+                ],
+            ],
+            'non-existing server' => [
+                'non_existent',
+                null,
+            ],
+            'empty string server key' => [
+                '',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::hasServer
+     */
+    #[DataProvider('provideHasServerData')]
+    public function testHasServer(string $serverKey, bool $expected): void
+    {
+        $result = $this->registry->hasServer($serverKey);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function provideHasServerData(): array
+    {
+        return [
+            'existing server default' => ['default', true],
+            'existing server simple_rest' => ['simple_rest', true],
+            'existing server analytics' => ['analytics', true],
+            'non-existing server' => ['non_existent', false],
+            'empty string' => ['', false],
+            'case sensitive check' => ['DEFAULT', false], // Should be case-sensitive
+        ];
+    }
+
+    /**
+     * @covers ::getServerKeys
+     */
+    public function testGetServerKeys(): void
+    {
+        $expected = ['default', 'simple_rest', 'analytics'];
+
+        $result = $this->registry->getServerKeys();
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getAllServerConfigurations
+     * @covers ::getServerKeys
+     */
+    public function testEmptyServerConfigurationRegistry(): void
+    {
+        $emptyRegistry = new ServerConfigurationRegistry([]);
+
+        $this->assertSame([], $emptyRegistry->getAllServerConfigurations());
+        $this->assertSame([], $emptyRegistry->getServerKeys());
+        $this->assertFalse($emptyRegistry->hasServer('any_key'));
+        $this->assertNull($emptyRegistry->getServerConfiguration('any_key'));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getServerConfiguration
+     * @covers ::hasServer
+     * @covers ::getServerKeys
+     */
+    public function testSingleServerConfiguration(): void
+    {
+        $singleServerConfig = [
+            'only_server' => [
+                'name' => 'Only Server',
+                'title' => 'The Only Server',
+                'version' => '3.0.0',
+            ],
+        ];
+
+        $registry = new ServerConfigurationRegistry($singleServerConfig);
+
+        $this->assertTrue($registry->hasServer('only_server'));
+        $this->assertFalse($registry->hasServer('other_server'));
+        $this->assertSame(['only_server'], $registry->getServerKeys());
+        $this->assertSame($singleServerConfig['only_server'], $registry->getServerConfiguration('only_server'));
+        $this->assertNull($registry->getServerConfiguration('other_server'));
+    }
+
+    /**
+     * @covers ::getServerConfiguration
+     */
+    public function testGetServerConfigurationWithMinimalData(): void
+    {
+        $minimalConfig = [
+            'minimal' => [
+                'name' => 'Minimal Server',
+                'version' => '1.0.0',
+                // No title field
+            ],
+        ];
+
+        $registry = new ServerConfigurationRegistry($minimalConfig);
+        $result = $registry->getServerConfiguration('minimal');
+
+        $this->assertSame([
+            'name' => 'Minimal Server',
+            'version' => '1.0.0',
+        ], $result);
+
+        // Verify that title is not present in the result
+        $this->assertArrayNotHasKey('title', $result);
+    }
+}

--- a/tests/Service/ToolRegistryTest.php
+++ b/tests/Service/ToolRegistryTest.php
@@ -160,6 +160,28 @@ class ToolRegistryTest extends KernelTestCase
     }
 
     /**
+     * @covers ::getTool
+     */
+    public function testGetToolWithServerKey(): void
+    {
+        // Test getting a global tool with any server key - should work
+        $globalTool = $this->registry->getTool('sum_numbers', 'server_a');
+        $this->assertInstanceOf(SumNumbersTool::class, $globalTool);
+
+        // Test getting a server-specific tool with correct server key - should work
+        $serverATool = $this->registry->getTool('server_a_tool', 'server_a');
+        $this->assertInstanceOf(ServerATool::class, $serverATool);
+
+        // Test getting a server-specific tool with wrong server key - should return null
+        $wrongServerTool = $this->registry->getTool('server_a_tool', 'server_b');
+        $this->assertNull($wrongServerTool);
+
+        // Test getting a server-specific tool with no server key - should work (backwards compatibility)
+        $noServerTool = $this->registry->getTool('server_a_tool');
+        $this->assertInstanceOf(ServerATool::class, $noServerTool);
+    }
+
+    /**
      * @covers ::getToolServerKey
      */
     #[DataProvider('provideToolServerKeyData')]

--- a/tests/Service/ToolRegistryTest.php
+++ b/tests/Service/ToolRegistryTest.php
@@ -7,6 +7,8 @@ namespace Ecourty\McpServerBundle\Tests\Service;
 use Ecourty\McpServerBundle\Service\ToolRegistry;
 use Ecourty\McpServerBundle\TestApp\Tool\CreateUserTool;
 use Ecourty\McpServerBundle\TestApp\Tool\MultiplyNumbersTool;
+use Ecourty\McpServerBundle\TestApp\Tool\ServerATool;
+use Ecourty\McpServerBundle\TestApp\Tool\ServerBTool;
 use Ecourty\McpServerBundle\TestApp\Tool\SumNumbersTool;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -45,6 +47,8 @@ class ToolRegistryTest extends KernelTestCase
             ['sum_numbers', SumNumbersTool::class],
             ['multiply_numbers', MultiplyNumbersTool::class],
             ['create_user', CreateUserTool::class],
+            ['server_a_tool', ServerATool::class],
+            ['server_b_tool', ServerBTool::class],
         ];
     }
 
@@ -95,6 +99,87 @@ class ToolRegistryTest extends KernelTestCase
                     'required' => ['emailAddress', 'username'],
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @covers ::getToolsDefinitions
+     */
+    public function testGetToolsDefinitionsWithoutServerFilter(): void
+    {
+        $definitions = $this->registry->getToolsDefinitions();
+
+        $this->assertCount(6, $definitions);
+
+        $toolNames = array_map(fn ($def) => $def->name, $definitions);
+        $this->assertContains('sum_numbers', $toolNames);
+        $this->assertContains('multiply_numbers', $toolNames);
+        $this->assertContains('create_user', $toolNames);
+        $this->assertContains('date_time', $toolNames);
+        $this->assertContains('server_a_tool', $toolNames);
+        $this->assertContains('server_b_tool', $toolNames);
+    }
+
+    /**
+     * @covers ::getToolsDefinitions
+     */
+    #[DataProvider('provideServerFilterData')]
+    public function testGetToolsDefinitionsWithServerFilter(string $serverKey, array $expectedToolNames): void
+    {
+        $definitions = $this->registry->getToolsDefinitions($serverKey);
+
+        $this->assertCount(\count($expectedToolNames), $definitions);
+
+        $actualToolNames = array_map(fn ($def) => $def->name, $definitions);
+        sort($actualToolNames);
+        sort($expectedToolNames);
+
+        $this->assertSame($expectedToolNames, $actualToolNames);
+    }
+
+    public static function provideServerFilterData(): array
+    {
+        return [
+            'default server includes global tools and default server tools' => [
+                'serverKey' => 'default',
+                'expectedToolNames' => ['sum_numbers', 'multiply_numbers', 'create_user', 'date_time'], // Global tools (no serverKey specified)
+            ],
+            'server_a includes global tools and server_a tools' => [
+                'serverKey' => 'server_a',
+                'expectedToolNames' => ['sum_numbers', 'multiply_numbers', 'create_user', 'date_time', 'server_a_tool'],
+            ],
+            'server_b includes global tools and server_b tools' => [
+                'serverKey' => 'server_b',
+                'expectedToolNames' => ['sum_numbers', 'multiply_numbers', 'create_user', 'date_time', 'server_b_tool'],
+            ],
+            'non-existent server includes only global tools' => [
+                'serverKey' => 'non_existent',
+                'expectedToolNames' => ['sum_numbers', 'multiply_numbers', 'create_user', 'date_time'],
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::getToolServerKey
+     */
+    #[DataProvider('provideToolServerKeyData')]
+    public function testGetToolServerKey(string $toolName, ?string $expectedServerKey): void
+    {
+        $serverKey = $this->registry->getToolServerKey($toolName);
+
+        $this->assertSame($expectedServerKey, $serverKey);
+    }
+
+    public static function provideToolServerKeyData(): array
+    {
+        return [
+            'global tool has no server key' => ['sum_numbers', null],
+            'global tool has no server key (multiply)' => ['multiply_numbers', null],
+            'global tool has no server key (create_user)' => ['create_user', null],
+            'global tool has no server key (date_time)' => ['date_time', null],
+            'server_a tool has server_a key' => ['server_a_tool', 'server_a'],
+            'server_b tool has server_b key' => ['server_b_tool', 'server_b'],
+            'non-existent tool returns null' => ['non_existent_tool', null],
         ];
     }
 }

--- a/tests/TestApp/config/packages/mcp_server.yaml
+++ b/tests/TestApp/config/packages/mcp_server.yaml
@@ -3,3 +3,12 @@ mcp_server:
     name: My Test MCP Server
     title: My Test MCP Server Title
     version: 1.0.1
+  servers:
+    server_a:
+      name: Server A
+      title: Server A Title
+      version: 1.0.0
+    server_b:
+      name: Server B
+      title: Server B Title
+      version: 1.0.0

--- a/tests/TestApp/src/Prompt/ServerAPrompt.php
+++ b/tests/TestApp/src/Prompt/ServerAPrompt.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\TestApp\Prompt;
+
+use Ecourty\McpServerBundle\Attribute\AsPrompt;
+use Ecourty\McpServerBundle\Enum\PromptRole;
+use Ecourty\McpServerBundle\IO\Prompt\Content\TextContent;
+use Ecourty\McpServerBundle\IO\Prompt\PromptMessage;
+use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
+use Ecourty\McpServerBundle\Prompt\Argument;
+use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
+
+#[AsPrompt(
+    name: 'server-a-prompt',
+    description: 'Prompt only available on server A',
+    server: 'server_a',
+    arguments: [
+        new Argument(name: 'input', description: 'The input text', allowUnsafe: true),
+    ],
+)]
+class ServerAPrompt
+{
+    public function __invoke(ArgumentCollection $arguments): PromptResult
+    {
+        return new PromptResult(
+            description: 'Server A prompt result',
+            messages: [
+                new PromptMessage(
+                    role: PromptRole::ASSISTANT,
+                    content: new TextContent('Response from Server A'),
+                ),
+            ],
+        );
+    }
+}

--- a/tests/TestApp/src/Prompt/ServerBPrompt.php
+++ b/tests/TestApp/src/Prompt/ServerBPrompt.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\TestApp\Prompt;
+
+use Ecourty\McpServerBundle\Attribute\AsPrompt;
+use Ecourty\McpServerBundle\Enum\PromptRole;
+use Ecourty\McpServerBundle\IO\Prompt\Content\TextContent;
+use Ecourty\McpServerBundle\IO\Prompt\PromptMessage;
+use Ecourty\McpServerBundle\IO\Prompt\PromptResult;
+use Ecourty\McpServerBundle\Prompt\Argument;
+use Ecourty\McpServerBundle\Prompt\ArgumentCollection;
+
+#[AsPrompt(
+    name: 'server-b-prompt',
+    description: 'Prompt only available on server B',
+    server: 'server_b',
+    arguments: [
+        new Argument(name: 'input', description: 'The input text', allowUnsafe: true),
+    ],
+)]
+class ServerBPrompt
+{
+    public function __invoke(ArgumentCollection $arguments): PromptResult
+    {
+        return new PromptResult(
+            description: 'Server B prompt result',
+            messages: [
+                new PromptMessage(
+                    role: PromptRole::ASSISTANT,
+                    content: new TextContent('Response from Server B'),
+                ),
+            ],
+        );
+    }
+}

--- a/tests/TestApp/src/Tool/ServerATool.php
+++ b/tests/TestApp/src/Tool/ServerATool.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\TestApp\Tool;
+
+use Ecourty\McpServerBundle\Attribute\AsTool;
+use Ecourty\McpServerBundle\IO\TextToolResult;
+use Ecourty\McpServerBundle\IO\ToolResult;
+use Ecourty\McpServerBundle\TestApp\Model\SumNumbers;
+
+#[AsTool(
+    name: 'server_a_tool',
+    description: 'Tool only available on server A',
+    server: 'server_a',
+)]
+class ServerATool
+{
+    public function __invoke(SumNumbers $data): ToolResult
+    {
+        return new ToolResult(elements: [new TextToolResult(content: 'Server A Tool Result')]);
+    }
+}

--- a/tests/TestApp/src/Tool/ServerBTool.php
+++ b/tests/TestApp/src/Tool/ServerBTool.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecourty\McpServerBundle\TestApp\Tool;
+
+use Ecourty\McpServerBundle\Attribute\AsTool;
+use Ecourty\McpServerBundle\IO\TextToolResult;
+use Ecourty\McpServerBundle\IO\ToolResult;
+use Ecourty\McpServerBundle\TestApp\Model\SumNumbers;
+
+#[AsTool(
+    name: 'server_b_tool',
+    description: 'Tool only available on server B',
+    server: 'server_b',
+)]
+class ServerBTool
+{
+    public function __invoke(SumNumbers $data): ToolResult
+    {
+        return new ToolResult(elements: [new TextToolResult(content: 'Server B Tool Result')]);
+    }
+}


### PR DESCRIPTION
fixes #21

I used a quiet Friday afternoon and gave it a try to implement support for multiple MCP servers (with a little help of Claude). 

### Configuration of servers
```yaml
mcp_server:
  # Default server configuration (backwards compatible)
  server:
    name: 'Main Server'
    title: 'Main MCP Server'
    version: '1.0.0'
  
  # Additional servers
  servers:
    api_server:
      name: 'API Server'
      title: 'External API Integration Server'
      version: '1.0.0'
    data_server:
      name: 'Data Server'
      title: 'Data Processing Server'
      version: '1.0.0'
```

### Assigning Tools, Resources, and Prompts to Servers
```php
#[AsTool(
    name: 'process_data',
    description: 'Processes large datasets',
    server: 'data_server' // Assign to data_server
)]
class ProcessDataTool
{
    public function __invoke(ProcessDataSchema $schema): ToolResult
    {
        // Tool logic here
    }
}
```

### Routing to Different Servers
```yaml
# Default server route
mcp_default:
  path: /mcp
  controller: mcp_server.entrypoint_controller
  defaults:
    serverKey: default
# API server route
mcp_api_server:
  path: /mcp/api
  controller: mcp_server.entrypoint_controller
  defaults:
    serverKey: api_server
# Data server route
mcp_data_server:
  path: /vendorB/data
  controller: mcp_server.entrypoint_controller
  defaults:
    serverKey: data_server
```

I'm not sure how you 'public' you see the services of this bundle. Strictly speaking, adding parameters to methods of diverse services could be seen as BC break. 
If they are seen as BC breaks, we also could cleanup `InitializeMethodHandler.php` a bit more. 

Any feedback welcome...